### PR TITLE
Resize map to trigger legend redraw

### DIFF
--- a/main.js
+++ b/main.js
@@ -620,9 +620,9 @@ define([
 						query.where = qwhere;
 					}
 
-					this.featureLayer.selectFeatures(query,FeatureLayer.SELECTION_NEW) 
-					
-				   
+					this.featureLayer.selectFeatures(query,FeatureLayer.SELECTION_NEW)
+						// Trigger legend redraw.
+						.then(this.map.resize);
 			   },
 
 


### PR DESCRIPTION
This triggers a redraw of the legend control after updating custom legend content.

Depends on https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/668
